### PR TITLE
🐳  Reduce production docker image size

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -2,20 +2,9 @@ ARG RUBY_VERSION
 FROM ruby:$RUBY_VERSION-slim-buster
 
 ARG BUNDLER_VERSION
-ARG NODE_MAJOR
-ARG YARN_VERSION
-
-# ソースリストにNodeJSを追加
-RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
-
-# ソースリストにYarnを追加
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -\
-  && echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
 
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade &&\
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends\
-    nodejs\
-    yarn=$YARN_VERSION-1 &&\
     build-essential libmariadb-dev &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
@@ -37,10 +26,9 @@ WORKDIR /app
 # Store puma pids file
 RUN mkdir -p tmp/pids
 
-ADD Gemfile Gemfile.lock package.json yarn.lock ./
+ADD ./ /app
 RUN gem update --system &&\
     gem install bundler:$BUNDLER_VERSION &&\
-    bundle install --without development test &&\
-    yarn install
-ADD ./ /app
+    bundle install --without development test
+
 CMD bundle exec pumactl start

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,5 +1,5 @@
 ARG RUBY_VERSION
-FROM ruby:$RUBY_VERSION-buster
+FROM ruby:$RUBY_VERSION-slim-buster
 
 ARG BUNDLER_VERSION
 ARG NODE_MAJOR
@@ -14,9 +14,9 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -\
 
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade &&\
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends\
-    build-essential\
     nodejs\
     yarn=$YARN_VERSION-1 &&\
+    build-essential libmariadb-dev &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
     truncate -s 0 /var/log/*log

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -22,8 +22,6 @@ image:
     args:
       RUBY_VERSION: 3.0.1
       BUNDLER_VERSION: 2.2.16
-      NODE_MAJOR: 14
-      YARN_VERSION: 1.22.5
   # Port exposed through your container to route traffic to it.
   port: 3000
 


### PR DESCRIPTION
## Description

```
$ docker image ls | grep chronos 
353381651656.dkr.ecr.ap-northeast-1.amazonaws.com/chronos/rails  e163b65  041deda1d651   22 minutes ago      523MB  # Remove Node.js and yarn
353381651656.dkr.ecr.ap-northeast-1.amazonaws.com/chronos/rails  <none>   3feb22e5d7df   56 minutes ago      850MB  # slim-buster
353381651656.dkr.ecr.ap-northeast-1.amazonaws.com/chronos/rails  c835be4  e60e9420e69d   2 hours ago         1.32GB # Original
```

## TODO
- [x] Change base image to slim-burster
- [x] Remove Node.js and yarn from prodcution