### PR TITLE
Pass `RAILS_MASTER_KEY` from Systems Manager Parameter Store 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ log
 tmp
 test
 node_modules
+config/master.key

--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ $ docker-compose up -d
 
 Deploy with [AWS Copilot](https://aws.github.io/copilot-cli/).
 
+### Secrets
+
+Save `RAILS_MASTER_KEY` to AWS Systems Manager Parameter Store (SSM).
+
+ref: https://aws.github.io/copilot-cli/docs/developing/secrets/
+
+```sh
+$ aws ssm put-parameter \
+  --name /copilot/applications/chronos/components/rails/RAILS_MASTER_KEY \
+  --value YOUR_RAILS_MASTER_KEY \
+  --type SecureString \
+  --tags Key=copilot-environment,Value=test \
+         Key=copilot-application,Value=chronos
+```
+
+### Infra
+
 ```sh
 # Create application
 $ copilot init
@@ -25,4 +42,11 @@ $ copilot svc init
 
 # Deploy
 $ copilot svc deploy
+```
+
+### Cleaning
+
+```sh
+$ aws ssm delete-parameter --name /copilot/applications/chronos/components/rails/RAILS_MASTER_KEY
+$ copilot app delete
 ```

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -38,8 +38,9 @@ exec: true     # Enable running commands in your container.
 variables:                    # Pass environment variables as key value pairs.
  RAILS_LOG_TO_STDOUT: true
 
-#secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
-#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
+secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+# GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
+ RAILS_MASTER_KEY: /copilot/applications/chronos/components/rails/RAILS_MASTER_KEY
 
 # You can override any of the values defined above by environment.
 #environments:


### PR DESCRIPTION
## Description

Save `RAILS_MASTER_KEY` to Systems Manager Parameter Store.
and, pass it to ECS container from environment variables.

## TODO
- [x] Remove `config/mater.key` from Docker image
- [x] Save `RAILS_MASTER_KEY` to System Manager Parameter Store
- [x] Update README