### PR TITLE
Run migration in deployment of GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,13 @@ jobs:
     - name: Assets precompile
       run: |
         bundle exec rails assets:precompile
+    - name: Migration
+      run: |
+        # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
+        copilot svc exec \
+          --command 'bin/rails db:migrate' \
+          --app chronos \
+          --env test
     - name: Deploy Rails service to test environment
       run: |
         copilot svc deploy --app chronos --env test --name rails

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,13 @@ jobs:
         curl -Lo copilot-linux https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
         chmod +x copilot-linux
         sudo mv copilot-linux /usr/local/bin/copilot
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0.1
+        bundler-cache: true 
+    - name: Assets precompile
+      run: |
+        bundle exec rails assets:precompile
     - name: Deploy Rails service to test environment
       run: |
         copilot svc deploy --app chronos --env test --name rails

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy service with AWS Copilot
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ap-northeast-1
+    - name: Setup AWS Copilot
+      run: |
+        curl -Lo copilot-linux https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
+        chmod +x copilot-linux
+        sudo mv copilot-linux /usr/local/bin/copilot
+    - name: Deploy Rails service to test environment
+      run: |
+        copilot svc deploy --app chronos --env test --name rails

--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ $ copilot svc deploy
 $ aws ssm delete-parameter --name /copilot/applications/chronos/components/rails/RAILS_MASTER_KEY
 $ copilot app delete
 ```
+
+## Deployment
+
+Running a deployment workflow using [GitHub CLI](https://cli.github.com/).
+
+```sh
+$ gh workflow run
+? Select a workflow  [Use arrows to move, type to filter]
+> Deploy service with AWS Copilot (deploy.yml)
+```


### PR DESCRIPTION
## Description

Run `rails db:migrate` in deployment.

Now, AWS Copilot dose not support to run task same as service configuration.
https://github.com/aws/copilot-cli/issues/2159
so, run `rails db:migrate` with `copilot svc exec` at this stage.

## TODO
- [x] Run migration in deployment of GitHub Actions
- [x] Add GitHub Actions instruction