### PR TITLE
Reduce deployment time

### DIFF
--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -12,7 +12,12 @@ http:
   # To match all requests you can use the "/" path.
   path: '/'
   # You can specify a custom health check path. The default is "/".
-  # healthcheck: '/'
+  healthcheck:
+    path: '/'
+    healthy_threshold: 2
+    unhealthy_threshold: 2
+    interval: 5s
+    timeout: 2s
 
 # Configuration for your containers and service.
 image:


### PR DESCRIPTION
## Description

Modify health check configuration to reduce deployment time.
ref: https://github.com/aws/copilot-cli/issues/2190#issuecomment-823406909

Default health check configuration.
https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#http-healthcheck
```yml
http:
  healthcheck:
    path: '/'
    success_codes: '200'
    healthy_threshold: 3
    unhealthy_threshold: 2
    interval: 15s
    timeout: 10s
```

### Before
```sh
- Updating the infrastructure for stack chronos-test-rails                    [update complete]  [314.8s]
  - An ECS service to run and maintain your tasks in the environment cluster  [update complete]  [286.9s]
    Deployments                                                                                   
               Revision  Rollout      Desired  Running  Failed  Pending                                   
      PRIMARY  33        [completed]  1        1        0       0                                         
  - An ECS task definition to group your containers and run them on ECS       [delete complete]  [3.8s]
```

### After
```sh
- Updating the infrastructure for stack chronos-test-rails                    [update complete]  [290.8s]
  - An ECS service to run and maintain your tasks in the environment cluster  [update complete]  [263.6s]
    Deployments                                                                                   
               Revision  Rollout      Desired  Running  Failed  Pending                                   
      PRIMARY  34        [completed]  1        1        0       0                                         
  - A target group to connect the load balancer to your service               [update complete]  [0.0s]
  - An ECS task definition to group your containers and run them on ECS       [delete complete]  [3.1s]
```

## TODO
- [x] Modify health check configuration to reduce deployment interval