### PR TITLE
Improve migration in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         bundler-cache: true 
     - name: Assets precompile
       run: |
-        bundle exec rails assets:precompile
+        bin/rails assets:precompile
 
     - name: Login to Amazon ECR
       id: login-ecr
@@ -41,7 +41,7 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
-    - name: Build and push
+    - name: Build docker image
       id: docker-build
       uses: docker/build-push-action@v2
       with:
@@ -56,7 +56,7 @@ jobs:
         tags: ${{ steps.login-ecr.outputs.registry }}/chronos/rails:${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-    - name: Push image to Amazon ECR
+    - name: Push docker image to Amazon ECR
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: chronos/rails   
@@ -68,9 +68,9 @@ jobs:
       run: |
         copilot svc deploy --app chronos --env dev --name rails
     # TODO: Run migratoin before copilot sevice deployment
-    - name: Migration
+    - name: Excecute database migration
       run: |
-        # https://aws.github.io/copilot-cli/docs/commands/task-run/
+        # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
         copilot svc exec \
           --command 'bin/rails db:migrate' \
           --app chronos \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,20 +49,20 @@ jobs:
           BUNDLER_VERSION=2.2.16
         push: false
         load: true
-        tags: shgtkshruch/chronos:1.0.0
+        tags: ${{ github.repository }}:1.0.0
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
     - name: Check docker images
       run: |
         docker image ls
-    # - name: Migration
-    #   run: |
-    #     # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
-    #     copilot task run \
-    #       --command 'bin/rails db:migrate' \
-    #       --app chronos \
-    #       --env dev \
-    #       --image 
+    - name: Migration
+      run: |
+        # https://aws.github.io/copilot-cli/docs/commands/task-run/
+        copilot task run \
+          --command 'bin/rails db:migrate' \
+          --app chronos \
+          --env dev \
+          --image $GITHUB_REPOSITORY:1.0.0
     # - name: Deploy Rails service to test environment
     #   run: |
     #     copilot svc deploy --app chronos --env test --name rails

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,42 @@ jobs:
     - name: Assets precompile
       run: |
         bundle exec rails assets:precompile
-    - name: Migration
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        context: .
+        file: ./Dockerfile.prod
+        build-args: |
+          RUBY_VERSION=3.0.1
+          BUNDLER_VERSION=2.2.16
+        push: false
+        load: true
+        tags: shgtkshruch/chronos:1.0.0
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
+    - name: Check docker images
       run: |
-        # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
-        copilot svc exec \
-          --command 'bin/rails db:migrate' \
-          --app chronos \
-          --env test
-    - name: Deploy Rails service to test environment
-      run: |
-        copilot svc deploy --app chronos --env test --name rails
+        docker image ls
+    # - name: Migration
+    #   run: |
+    #     # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
+    #     copilot task run \
+    #       --command 'bin/rails db:migrate' \
+    #       --app chronos \
+    #       --env dev \
+    #       --image 
+    # - name: Deploy Rails service to test environment
+    #   run: |
+    #     copilot svc deploy --app chronos --env test --name rails

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-
     - name: Build and push
-      id: docker_build
+      id: docker-build
       uses: docker/build-push-action@v2
       with:
         builder: ${{ steps.buildx.outputs.name }}
@@ -56,9 +56,6 @@ jobs:
         tags: ${{ steps.login-ecr.outputs.registry }}/copilot-chronos:${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-    - name: Check docker images
-      run: |
-        docker image ls
     - name: Push image to Amazon ECR
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -67,6 +64,13 @@ jobs:
       run: |
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
+    - name: Fetch secrets from Copilot
+      id: copilot-secret
+      run: |
+        RAILS_MASTER_KEY=$(copilot svc show --name rails --json | jq .secrets[0].valueFrom)
+        RAILSCLUSTER_SECRET=$(copilot svc show --name rails --json | jq .secrets[1].valueFrom)
+        echo "::set-output name=RAILS_MASTER_KEY::$RAILS_MASTER_KEY"
+        echo "::set-output name=RAILSCLUSTER_SECRET::$RAILSCLUSTER_SECRET"
     - name: Migration
       run: |
         # https://aws.github.io/copilot-cli/docs/commands/task-run/
@@ -74,7 +78,10 @@ jobs:
           --command 'bin/rails db:migrate' \
           --app chronos \
           --env dev \
-          --image ${{ steps.login-ecr.outputs.registry }}/copilot-chronos:${{ github.sha }}
+          --image ${{ steps.login-ecr.outputs.registry }}/copilot-chronos:${{ github.sha }} \
+          --env-vars  \
+            RAILS_MASTER_KEY=ff6ac7006c88164593db4d315ae27a54,\
+            RAILSCLUSTER_SECRET="{"dbClusterIdentifier":"chronos-dev-rails-addonssta-railsclusterdbcluster-owaovnhbh772","password":"x3hYXq4toujqNrOF","dbname":"app_production","engine":"mysql","port":3306,"host":"chronos-dev-rails-addonssta-railsclusterdbcluster-owaovnhbh772.cluster-caz8jviirpne.ap-northeast-1.rds.amazonaws.com","username":"admin"}"
     # - name: Deploy Rails service to test environment
     #   run: |
     #     copilot svc deploy --app chronos --env test --name rails

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,9 @@ jobs:
       with:
         ruby-version: 3.0.1
         bundler-cache: true 
-    # - name: Assets precompile
-    #   run: |
-    #     bundle exec rails assets:precompile
+    - name: Assets precompile
+      run: |
+        bundle exec rails assets:precompile
 
     - name: Login to Amazon ECR
       id: login-ecr
@@ -53,35 +53,26 @@ jobs:
           BUNDLER_VERSION=2.2.16
         push: false
         load: true
-        tags: ${{ steps.login-ecr.outputs.registry }}/copilot-chronos:${{ github.sha }}
+        tags: ${{ steps.login-ecr.outputs.registry }}/chronos/rails:${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
     - name: Push image to Amazon ECR
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: copilot-chronos
+        ECR_REPOSITORY: chronos/rails   
         IMAGE_TAG: ${{ github.sha }}
       run: |
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-    - name: Fetch secrets from Copilot
-      id: copilot-secret
+    - name: Deploy Rails service to dev environment
       run: |
-        RAILS_MASTER_KEY=$(copilot svc show --name rails --json | jq .secrets[0].valueFrom)
-        RAILSCLUSTER_SECRET=$(copilot svc show --name rails --json | jq .secrets[1].valueFrom)
-        echo "::set-output name=RAILS_MASTER_KEY::$RAILS_MASTER_KEY"
-        echo "::set-output name=RAILSCLUSTER_SECRET::$RAILSCLUSTER_SECRET"
+        copilot svc deploy --app chronos --env dev --name rails
+    # TODO: Run migratoin before copilot sevice deployment
     - name: Migration
       run: |
         # https://aws.github.io/copilot-cli/docs/commands/task-run/
-        copilot task run \
+        copilot svc exec \
           --command 'bin/rails db:migrate' \
           --app chronos \
-          --env dev \
-          --image ${{ steps.login-ecr.outputs.registry }}/copilot-chronos:${{ github.sha }} \
-          --env-vars  \
-            RAILS_MASTER_KEY=ff6ac7006c88164593db4d315ae27a54,\
-            RAILSCLUSTER_SECRET="{"dbClusterIdentifier":"chronos-dev-rails-addonssta-railsclusterdbcluster-owaovnhbh772","password":"x3hYXq4toujqNrOF","dbname":"app_production","engine":"mysql","port":3306,"host":"chronos-dev-rails-addonssta-railsclusterdbcluster-owaovnhbh772.cluster-caz8jviirpne.ap-northeast-1.rds.amazonaws.com","username":"admin"}"
-    # - name: Deploy Rails service to test environment
-    #   run: |
-    #     copilot svc deploy --app chronos --env test --name rails
+          --name rails \
+          --env dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,13 @@ jobs:
       with:
         ruby-version: 3.0.1
         bundler-cache: true 
-    - name: Assets precompile
-      run: |
-        bundle exec rails assets:precompile
+    # - name: Assets precompile
+    #   run: |
+    #     bundle exec rails assets:precompile
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -49,12 +53,20 @@ jobs:
           BUNDLER_VERSION=2.2.16
         push: false
         load: true
-        tags: ${{ github.repository }}:1.0.0
+        tags: ${{ steps.login-ecr.outputs.registry }}/copilot-chronos:${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
     - name: Check docker images
       run: |
         docker image ls
+    - name: Push image to Amazon ECR
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: copilot-chronos
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
     - name: Migration
       run: |
         # https://aws.github.io/copilot-cli/docs/commands/task-run/
@@ -62,7 +74,7 @@ jobs:
           --command 'bin/rails db:migrate' \
           --app chronos \
           --env dev \
-          --image $GITHUB_REPOSITORY:1.0.0
+          --image ${{ steps.login-ecr.outputs.registry }}/copilot-chronos:${{ github.sha }}
     # - name: Deploy Rails service to test environment
     #   run: |
     #     copilot svc deploy --app chronos --env test --name rails


### PR DESCRIPTION
## Description

Run `rails db:migration` after `copilot svc deploy` in GitHub Actions.
Reduce docker build time by enabling cache.

## TODO
- [x] Build docker image with cache
- [x] Push docker image to Amazon ECR
- [x] Execute migration after `copilot svc deploy` 
  - I really wanted to migration before, but `copilot task run` is not support environment variable and secret values same as service.