### PR TITLE
Install lograge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+gem "lograge"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,11 @@ GEM
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -145,6 +150,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.1.1)
+    request_store (1.5.0)
+      rack (>= 1.4)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -205,6 +212,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  lograge
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
@@ -222,4 +230,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.16
+   2.2.17

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::Base
+  def append_info_to_payload(payload)
+    super
+    payload[:ip] = request.remote_ip
+  end
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
   config.lograge.enabled = true
+  config.lograge.formatter = Lograge::Formatters::Json.new
 
   config.lograge.custom_options = lambda do |event|
     {

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,3 +1,10 @@
 Rails.application.configure do
   config.lograge.enabled = true
+
+  config.lograge.custom_options = lambda do |event|
+    {
+      ip: event.payload[:ip],
+      params: event.payload[:params]
+    }
+  end
 end


### PR DESCRIPTION
## Description

Install [lograge](https://github.com/roidrage/lograge) to organizes Rails logs.
Output Rails logs to JSON format.
JSON is easy to analysis with Amazon Athena or same services.

### Logs

```json
{
   "method":"GET",
   "path":"/people",
   "format":"html",
   "controller":"PeopleController",
   "action":"index",
   "status":200,
   "duration":45.26,
   "view":43.01,
   "db":1.35,
   "ip":"172.22.0.1",
   "params":{
      "controller":"people",
      "action":"index"
   }
}
```

## TODO
- [x] Install [lograge](https://github.com/roidrage/lograge)
- [x] lograge configuration

## References
- [How to Collect, Customize, and Manage Rails Application Logs _ Datadog](https://www.datadoghq.com/ja/blog/managing-rails-application-logs/)
- [Include remote IP address in default output · Issue #10 · roidrage_lograge](https://github.com/roidrage/lograge/issues/10)