### PR TITLE
Create RDS instance instead of Aurora Serverless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -\
 
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade &&\
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends\
-    build-essential\
+    build-essential vim\
     nodejs\
     yarn=$YARN_VERSION-1 &&\
     apt-get clean &&\

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 gem "lograge"
+gem 'aws-sdk-rds'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,18 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    aws-eventstream (1.1.1)
+    aws-partitions (1.461.0)
+    aws-sdk-core (3.114.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-rds (1.118.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.3)
+      aws-eventstream (~> 1, >= 1.0.2)
     bindex (0.8.1)
     bootsnap (1.7.3)
       msgpack (~> 1.0)
@@ -86,6 +98,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    jmespath (1.4.0)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -207,6 +220,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-rds
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)


### PR DESCRIPTION
## Description

AWS Copilot create Aurora Serverless as default RDS, and its credentials to store AWS Secrets Manager.
The credentials are pass to ECS container by copilot with `--secrets` flag.
So, now we need AWS Secrets Manager IAM role in migration.

This PR to store RDS credentials to [Rails Credentials](https://edgeguides.rubyonrails.org/security.html#custom-credentials) to resolve in Rails world. (not need IAM role!)

## TODO
- [x] Install AWS SDK Ruby
- [ ] Create RDS by `bin/setup-rds` scripts
- [ ] Add delete RDS scripts
- [ ] Run migration in GitHub Actions before `copilot svc deploy` command
- [ ] Remove Aurora Serverless template
