### PR TITLE
Introduce docker layer cache in GitHub Actions 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,21 +9,25 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ap-northeast-1
+
     - name: Setup AWS Copilot
       run: |
         curl -Lo copilot-linux https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
         chmod +x copilot-linux
         sudo mv copilot-linux /usr/local/bin/copilot
+
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0.1
-        bundler-cache: true 
+        bundler-cache: true
+
     - name: Assets precompile
       run: |
         bin/rails assets:precompile
@@ -31,9 +35,11 @@ jobs:
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
+  
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
+
     - name: Cache Docker layers
       uses: actions/cache@v2
       with:
@@ -41,6 +47,7 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
+  
     - name: Build docker image
       id: docker-build
       uses: docker/build-push-action@v2
@@ -51,28 +58,24 @@ jobs:
         build-args: |
           RUBY_VERSION=3.0.1
           BUNDLER_VERSION=2.2.16
-        push: false
-        load: true
+        push: true
         tags: ${{ steps.login-ecr.outputs.registry }}/chronos/rails:${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
-    - name: Push docker image to Amazon ECR
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: chronos/rails   
-        IMAGE_TAG: ${{ github.sha }}
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+    - name: Move cache
       run: |
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-    - name: Deploy Rails service to dev environment
-      run: |
-        copilot svc deploy --app chronos --env dev --name rails
+    # - name: Deploy Rails service to dev environment
+    #   run: |
+    #     copilot svc deploy --app chronos --env dev --name rails
     # TODO: Run migratoin before copilot sevice deployment
-    - name: Excecute database migration
-      run: |
-        # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
-        copilot svc exec \
-          --command 'bin/rails db:migrate' \
-          --app chronos \
-          --name rails \
-          --env dev
+    # - name: Excecute database migration
+    #   run: |
+    #     # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
+    #     copilot svc exec \
+    #       --command 'bin/rails db:migrate' \
+    #       --app chronos \
+    #       --name rails \
+    #       --env dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         bin/rails assets:precompile
 
+    # Build Docker image
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
@@ -62,20 +63,25 @@ jobs:
         tags: ${{ steps.login-ecr.outputs.registry }}/chronos/rails:${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
     - name: Move cache
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-    # - name: Deploy Rails service to dev environment
-    #   run: |
-    #     copilot svc deploy --app chronos --env dev --name rails
+    - name: Deploy Rails service to dev environment
+      run: |
+        copilot svc deploy --app chronos --env dev --name rails
+  
     # TODO: Run migratoin before copilot sevice deployment
-    # - name: Excecute database migration
-    #   run: |
-    #     # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
-    #     copilot svc exec \
-    #       --command 'bin/rails db:migrate' \
-    #       --app chronos \
-    #       --name rails \
-    #       --env dev
+    - name: Excecute database migration
+      run: |
+        # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
+        copilot svc exec \
+          --command 'bin/rails db:migrate' \
+          --app chronos \
+          --name rails \
+          --env dev


### PR DESCRIPTION
## Description

Enable docker layer cache to docker image build in GitHub Actions.
1m57s -> 39s 🚀 

### Before
![スクリーンショット 2021-05-23 15 45 06](https://user-images.githubusercontent.com/5207601/119250885-11c21d00-bbde-11eb-9630-82e23d244539.png)

### After
![スクリーンショット 2021-05-23 15 44 11](https://user-images.githubusercontent.com/5207601/119250882-0ec72c80-bbde-11eb-84a9-92913bce6dcf.png)


## TODO
- [x] Enable docker layer cache

## References
- [GitHub ActionsのイメージビルドをDockerレイヤキャッシュで高速化（翻訳）｜TechRacho](https://techracho.bpsinc.jp/hachi8833/2021_05_14/107140)
- https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache