### PR TITLE
Reduce Docker image build size and deployment time 🚀 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        file: ./Dockerfile.prod
         target: bundle
         cache-from: type=local,src=/tmp/.buildx-cache/bundle
         cache-to: type=local,dest=/tmp/.buildx-cache-new/bundle
@@ -52,6 +53,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        file: ./Dockerfile.prod
         target: npm
         cache-from: type=local,src=/tmp/.buildx-cache/npm
         cache-to: type=local,dest=/tmp/.buildx-cache-new/npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,12 +17,6 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ap-northeast-1
 
-    - name: Setup AWS Copilot
-      run: |
-        curl -Lo copilot-linux https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
-        chmod +x copilot-linux
-        sudo mv copilot-linux /usr/local/bin/copilot
-
     # Build Docker image
     - name: Login to Amazon ECR
       id: login-ecr
@@ -86,6 +80,22 @@ jobs:
     environment:
       name: dev
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ap-northeast-1
+
+    - name: Setup AWS Copilot
+      run: |
+        curl -Lo copilot-linux https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
+        chmod +x copilot-linux
+        sudo mv copilot-linux /usr/local/bin/copilot
+
     - name: Deploy Rails service to dev environment
       run: |
         copilot svc deploy --app chronos --env dev --name rails

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,15 +23,6 @@ jobs:
         chmod +x copilot-linux
         sudo mv copilot-linux /usr/local/bin/copilot
 
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.0.1
-        bundler-cache: true
-
-    - name: Assets precompile
-      run: |
-        bin/rails assets:precompile
-
     # Build Docker image
     - name: Login to Amazon ECR
       id: login-ecr

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
         cache-from: |
           type=local,src=/tmp/.buildx-cache-new/bundle
           type=local,src=/tmp/.buildx-cache-new/npm
-        cache-to: type=inline
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -80,6 +80,12 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: dev
+    steps:
     - name: Deploy Rails service to dev environment
       run: |
         copilot svc deploy --app chronos --env dev --name rails

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,9 +56,6 @@ jobs:
         builder: ${{ steps.buildx.outputs.name }}
         context: .
         file: ./Dockerfile.prod
-        build-args: |
-          RUBY_VERSION=3.0.1
-          BUNDLER_VERSION=2.2.16
         push: true
         tags: ${{ steps.login-ecr.outputs.registry }}/chronos/rails:${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,22 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
+
+    - name: Build bundle stage
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        target: bundle
+        cache-from: type=local,src=/tmp/.buildx-cache/bundle
+        cache-to: type=local,dest=/tmp/.buildx-cache-new/bundle
+
+    - name: Build npm stage
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        target: npm
+        cache-from: type=local,src=/tmp/.buildx-cache/npm
+        cache-to: type=local,dest=/tmp/.buildx-cache-new/npm
   
     - name: Build docker image
       id: docker-build
@@ -58,8 +74,10 @@ jobs:
         file: ./Dockerfile.prod
         push: true
         tags: ${{ steps.login-ecr.outputs.registry }}/chronos/rails:${{ github.sha }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new
+        cache-from: |
+          type=local,src=/tmp/.buildx-cache-new/bundle
+          type=local,src=/tmp/.buildx-cache-new/npm
+        cache-to: type=inline
 
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,10 @@ jobs:
         chmod +x copilot-linux
         sudo mv copilot-linux /usr/local/bin/copilot
 
+    - name: Replace docker image tag to github sha
+      run: |
+        sed -i -e 's/<image_tag>/${{ github.sha }}/' copilot/rails/manifest.yml
+
     - name: Deploy Rails service to dev environment
       run: |
         copilot svc deploy --app chronos --env dev --name rails

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -54,6 +54,10 @@ RUN SECRET_KEY_BASE=dummy bin/rails assets:precompile \
 
 FROM base AS main
 
+# Add packages
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+      libmariadb-dev
+
 # Store puma pids file
 RUN mkdir -p tmp/pids
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,32 +1,66 @@
-FROM ruby:3.0.1-slim-buster
-
-RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade &&\
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends\
-    build-essential libmariadb-dev &&\
-    apt-get clean &&\
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
-    truncate -s 0 /var/log/*log
-
-# bundlerとPATHを設定
-ENV LANG=C.UTF-8\
-  GEM_HOME=/bundle\
-  BUNDLE_JOBS=4\
-  BUNDLE_RETRY=3
-ENV BUNDLE_PATH $GEM_HOME
-ENV BUNDLE_APP_CONFIG=$BUNDLE_PATH\
-  BUNDLE_BIN=$BUNDLE_PATH/bin
-ENV PATH /app/bin:$BUNDLE_BIN:$PATH
-ENV RAILS_ENV=production
+FROM ruby:3.0.1-slim-buster AS base
 
 WORKDIR /app
+
+# bundler configuration
+ENV LANG=C.UTF-8
+ENV RAILS_ENV production
+ENV BUNDLE_DEPLOYMENT true
+ENV BUNDLE_PATH vendor/bundle
+ENV BUNDLE_WITHOUT development:test
+
+RUN gem install bundler --no-document --version 2.2.16
+
+FROM base AS builder
+
+RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends\
+    build-essential \
+    libmariadb-dev \
+    curl \
+    gnupg \
+    nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && truncate -s 0 /var/log/*log
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install yarn
+
+FROM builder AS bundle
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install \
+      && rm -rf $BUNDLE_PATH/ruby/$RUBY_VERSION/cache/*
+
+FROM builder AS npm
+
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile \
+      && yarn cache clean
+
+FROM builder AS assets
+
+COPY . .
+
+COPY --from=bundle /app/vendor/bundle /app/vendor/bundle
+COPY --from=npm /app/node_modules node_modules
+
+# Set a dummy value to avoid errors when building docker image.
+# refs: https://github.com/rails/rails/issues/32947
+RUN SECRET_KEY_BASE=dummy bin/rails assets:precompile \
+      && rm -rf tmp/cache/*
+
+FROM base AS main
 
 # Store puma pids file
 RUN mkdir -p tmp/pids
 
-ADD Gemfile Gemfile.lock ./
-RUN gem update --system &&\
-    gem install bundler:2.2.16 &&\
-    bundle install --without development test
-ADD ./ ./
+COPY ./ ./
+
+COPY --from=bundle /app/vendor/bundle /app/vendor/bundle
+COPY --from=assets /app/public/assets public/assets
+COPY --from=assets /app/public/packs public/packs
 
 CMD bundle exec pumactl start

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,7 +1,4 @@
-ARG RUBY_VERSION
-FROM ruby:$RUBY_VERSION-slim-buster
-
-ARG BUNDLER_VERSION
+FROM ruby:3.0.1-slim-buster
 
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade &&\
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends\
@@ -28,7 +25,7 @@ RUN mkdir -p tmp/pids
 
 ADD Gemfile Gemfile.lock ./
 RUN gem update --system &&\
-    gem install bundler:$BUNDLER_VERSION &&\
+    gem install bundler:2.2.16 &&\
     bundle install --without development test
 ADD ./ ./
 

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -24,7 +24,7 @@ http:
 
 # Configuration for your containers and service.
 image:
-  location: 353381651656.dkr.ecr.ap-northeast-1.amazonaws.com/chronos/rails:latest
+  location: 353381651656.dkr.ecr.ap-northeast-1.amazonaws.com/chronos/rails:<image_tag>
   # Port exposed through your container to route traffic to it.
   port: 3000
 

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -24,12 +24,7 @@ http:
 
 # Configuration for your containers and service.
 image:
-  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
-  build:
-    dockerfile: ./Dockerfile.prod
-    args:
-      RUBY_VERSION: 3.0.1
-      BUNDLER_VERSION: 2.2.16
+  location: 353381651656.dkr.ecr.ap-northeast-1.amazonaws.com/chronos/rails:latest
   # Port exposed through your container to route traffic to it.
   port: 3000
 


### PR DESCRIPTION
## Description

Reduce Docker image size.
- Before: 1.04GB
- After: 204MB

And reduce deployment time to use ECR image in `copilot svc deploy` phase.

## TODO
- [x] Run `rails asset:precompile` in Docker container
- [x] Multi stage build for layer cache
- [x] Use pushed image to ECR in copilot deploy phase using [`image.location`](https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-location) in `manifest.yml`
- [x] Separate GitHub Actions steps to build and deploy

## Reference
- [Amazon ECSで動かすRailsアプリのDockerfileとGitHub Actionsのビルド設定 - メドピア開発者ブログ](https://tech.medpeer.co.jp/entry/2021/05/28/180408)