### PR TITLE
Add datadog container configuration 🐶 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 gem "lograge"
 gem "slack-notifier"
+gem 'ddtrace', require: 'ddtrace/auto_instrument'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
     childprocess (3.0.0)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    ddtrace (0.49.0)
+      ffi (~> 1.0)
+      msgpack
     erubi (1.10.0)
     ffi (1.15.0)
     globalid (0.4.2)
@@ -211,6 +214,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  ddtrace
   jbuilder (~> 2.7)
   listen (~> 3.3)
   lograge

--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -1,0 +1,3 @@
+Datadog.configure do |c|
+  c.use :rails, service_name: 'chronos-rails'
+end

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -49,6 +49,8 @@ sidecars:
     variables:
       ECS_FARGATE: true
       DD_APM_ENABLED: true
+      DD_SERVICE: chronos-rails
+      DD_DOCKER_ENV_AS_TAGS: true
 
 logging:
   destination:
@@ -64,7 +66,7 @@ logging:
 # Optional fields for more advanced use-cases.
 #
 variables:                    # Pass environment variables as key value pairs.
- RAILS_LOG_TO_STDOUT: true
+  RAILS_LOG_TO_STDOUT: true
 
 secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 # GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
@@ -72,9 +74,16 @@ secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 # You can override any of the values defined above by environment.
 environments:
   dev:
-    # ref: https://github.com/aws/copilot-cli/issues/2275#issuecomment-833646845
+    sidecars:
+      datadog-agent:
+        variables:
+          DD_ENV: dev
     secrets:
       RAILS_MASTER_KEY: /copilot/chronos/dev/secrets/RAILS_MASTER_KEY
   staging:
+    sidecars:
+      datadog-agent:
+        variables:
+          DD_ENV: staging
     secrets:
       RAILS_MASTER_KEY: /copilot/chronos/staging/secrets/RAILS_MASTER_KEY

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -40,6 +40,25 @@ sidecars:
     port: 80
     variables:
       RAILS_HOST: http://localhost:3000
+  datadog-agent:
+    image: datadog/agent:latest
+    port: 8126
+    secrets:
+      DD_API_KEY: /copilot/chronos/dev/secrets/DATADOG_API_KEY
+    variables:
+      ECS_FARGATE: true
+      DD_APM_ENABLED: true
+
+logging:
+  destination:
+    Name: datadog
+    Host: http-intake.logs.datadoghq.com
+    TLS: 'on'
+    dd_service: chronos-rails
+    dd_source: chronos-rails
+    provider: ecs
+  secretOptions:
+    apikey: /copilot/chronos/dev/secrets/DATADOG_API_KEY
 
 # Optional fields for more advanced use-cases.
 #

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -40,6 +40,7 @@ sidecars:
     port: 80
     variables:
       RAILS_HOST: http://localhost:3000
+  # https://docs.datadoghq.com/integrations/ecs_fargate/?tab=fluentbitandfirelens#trace-collection
   datadog-agent:
     image: datadog/agent:latest
     port: 8126


### PR DESCRIPTION
## Description

Send Rails and Nginx logs to Datadog.

## Datadog dashboard

### Infrastructure

#### Host Map
![スクリーンショット 2021-05-30 11 42 57](https://user-images.githubusercontent.com/5207601/120090290-36694800-c13c-11eb-9ccf-2c60221eb254.png)

#### Containers
![スクリーンショット 2021-05-30 11 44 03](https://user-images.githubusercontent.com/5207601/120090310-61ec3280-c13c-11eb-8855-d1090e2585f3.png)

### APM
![スクリーンショット 2021-05-30 11 39 20](https://user-images.githubusercontent.com/5207601/120090218-ca86df80-c13b-11eb-867e-8d7874b40afb.png)

### Logs
![スクリーンショット 2021-05-30 11 39 58](https://user-images.githubusercontent.com/5207601/120090220-cd81d000-c13b-11eb-8325-23e898e40b11.png)


## TODO
- [x] Integrate AWS and Datadog
- [x] Add [datadog-agent](https://docs.datadoghq.com/ja/integrations/ecs_fargate/?tab=fluentbitandfirelens#ecs-fargate-%E3%82%BF%E3%82%B9%E3%82%AF%E3%81%AE%E4%BD%9C%E6%88%90) container
- [x] Add [sidercar](https://aws.github.io/copilot-cli/docs/developing/sidecars/) container to transfer application logs to [Datadog with Firelens](https://docs.datadoghq.com/ja/integrations/ecs_fargate/?tab=fluentbitandfirelens#%E3%83%AD%E3%82%B0%E3%81%AE%E5%8F%8E%E9%9B%86)
- [x] Add Datadog APM to Rails

## References
- [DatadogでAWSインテグレーションのモニターを作成してみた _ DevelopersIO](https://dev.classmethod.jp/articles/datadog-aws-integration/)
- [Amazon Fargate - Datadog](https://docs.datadoghq.com/ja/integrations/ecs_fargate/?tab=fluentbitandfirelens)
- [統合サービスタグ付け - Datadog](https://docs.datadoghq.com/ja/getting_started/tagging/unified_service_tagging/?tab=kubernetes)
- [Monitor ECS Applications on AWS Fargate With Datadog - Datadog](https://www.datadoghq.com/ja/blog/monitor-aws-fargate/)
- [Monitoring Rails Applications With Datadog - Datadog](https://www.datadoghq.com/ja/blog/monitoring-rails-with-datadog/)