### PR TITLE
Fording Rails logs to Kinesis Data Firehose

### DIFF
--- a/copilot/rails/addons/firehose-iam.yml
+++ b/copilot/rails/addons/firehose-iam.yml
@@ -1,0 +1,15 @@
+Resources:
+  FirehosePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Action:
+          - firehose:PutRecordBatch
+          Resource: "*"
+Outputs:
+  FirehosePolicy:
+    Description: An addon ManagedPolicy gets used by the ECS task role
+    Value: !Ref FirehosePolicy

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -54,14 +54,10 @@ sidecars:
 
 logging:
   destination:
-    Name: datadog
-    Host: http-intake.logs.datadoghq.com
-    TLS: 'on'
-    dd_service: chronos-rails
-    dd_source: chronos-rails
-    provider: ecs
-  secretOptions:
-    apikey: /copilot/chronos/dev/secrets/DATADOG_API_KEY
+    # https://docs.aws.amazon.com/AmazonECS/latest/userguide/firelens-example-taskdefs.html#firelens-example-firehose
+    Name: firehose
+    region: ap-northeast-1
+    delivery_stream: chronos-rails-datadog
 
 # Optional fields for more advanced use-cases.
 #


### PR DESCRIPTION
## Description

### Log stream flow

![スクリーンショット 2021-06-06 14 45 14](https://user-images.githubusercontent.com/5207601/120913969-d2172d00-c6d5-11eb-9283-dcb008a43e49.png)

### Log format
```json
{
  "container_id": "5ffd952345504ed7b3f685ef657473b4-1555792190",
  "container_name": "rails",
  "ecs_cluster": "chronos-dev-Cluster-ZkKpMlR995rw",
  "ecs_task_arn": "arn:aws:ecs:ap-northeast-1:353381651656:task/chronos-dev-Cluster-ZkKpMlR995rw/5ffd952345504ed7b3f685ef657473b4",
  "ecs_task_definition": "chronos-dev-rails:54",
  "log": "I, [2021-06-06T05:11:20.697870 #7]  INFO -- : [c4193f76-6b6d-4220-99f6-34bb77fcd6c6] {\"method\":\"GET\",\"path\":\"/\",\"format\":\"html\",\"controller\":\"PagesController\",\"action\":\"main\",\"status\":200,\"duration\":1.81,\"view\":1.04,\"ip\":\"10.0.1.252\",\"params\":{\"controller\":\"pages\",\"action\":\"main\"}}",
  "source": "stdout"
}
```
### Datadog
![スクリーンショット 2021-06-06 14 43 39](https://user-images.githubusercontent.com/5207601/120913932-9c724400-c6d5-11eb-8e4b-252d1b46ce37.png)

## TODO
- [x] Fording Rails logs to Kinesis Data Firehose
- [x] Backup logs to store S3
- [x] Create IAM role to pug Rails logs to Kinesis Data Firehose stream

## References
- [AWS Startup Tech Meetup #3_ かんたんコンテナロギング選手権 - Speaker Deck](https://speakerdeck.com/prog893/aws-startup-tech-meetup-number-3-kantankontenaroginguxuan-shou-quan?slide=22)
- [Stream Logs to Datadog With Amazon Kinesis Data Firehose _ Datadog](https://www.datadoghq.com/ja/blog/stream-logs-with-kinesis-firehose-and-datadog/)
- [Example task definitions - Amazon ECS](https://docs.aws.amazon.com/AmazonECS/latest/userguide/firelens-example-taskdefs.html#firelens-example-firehose)
- [Sidecars - AWS Copilot CLI](https://aws.github.io/copilot-cli/docs/developing/sidecars/)