### PR TITLE
Add health check endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem "lograge"
 gem "slack-notifier"
 gem 'ddtrace', require: 'ddtrace/auto_instrument'
+gem 'rails-healthcheck'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,9 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-healthcheck (1.4.0)
+      actionpack
+      railties
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (6.1.3.1)
@@ -222,6 +225,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.1)
+  rails-healthcheck
   sass-rails (>= 6)
   selenium-webdriver
   slack-notifier

--- a/config/initializers/healthcheck.rb
+++ b/config/initializers/healthcheck.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Healthcheck.configure do |config|
+  config.success = 200
+  config.error = 503
+  config.verbose = false
+  config.route = '/healthcheck'
+  config.method = :get
+
+  # -- Custom Response --
+  # config.custom = lambda { |controller, checker|
+  #   return controller.render(plain: 'Everything is awesome!') unless checker.errored?
+  #   controller.verbose? ? controller.verbose_error(checker) : controller.head_error
+  # }
+
+  # -- Checks --
+  # config.add_check :database,     -> { ActiveRecord::Base.connection.execute('select 1') }
+  # config.add_check :migrations,   -> { ActiveRecord::Migration.check_pending! }
+  # config.add_check :cache,        -> { Rails.cache.read('some_key') }
+  # config.add_check :environments, -> { Dotenv.require_keys('ENV_NAME', 'ANOTHER_ENV') }
+end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -8,4 +8,8 @@ Rails.application.configure do
       params: event.payload[:params]
     }
   end
+
+  # Exclude heathcheck logs from rails logs
+  # https://github.com/linqueta/rails-healthcheck#ignoring-logs
+  config.lograge.ignore_actions = [Healthcheck::CONTROLLER_ACTION]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  Healthcheck.routes(self)
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'pages#main'
 

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -13,7 +13,7 @@ http:
   path: '/'
   # You can specify a custom health check path. The default is "/".
   healthcheck:
-    path: '/'
+    path: '/healthcheck'
     healthy_threshold: 2
     unhealthy_threshold: 2
     interval: 5s


### PR DESCRIPTION
## Description

Add health check endpoint using [Rails::Healthcheck](https://github.com/linqueta/rails-healthcheck#ignoring-logs) gem.
When using `/` path as a health check, it is not possible to distinguish between real user requests and health check requests.
So, this PR add new end point for health check.

## TODO
- [x] Install [Rails::Healthcheck](https://github.com/linqueta/rails-healthcheck#ignoring-logs) to add health check endpoint
- [x] Exclude health check logs from Rails logs
- [x] Set new health check endpoint in rails `manifest.yml`