### PR TITLE
Add `admin-rails` service to test multiple Load Balanced Web Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Create AWS resources (ex. VPC, ALB, Farge, RDS) with [AWS Copilot](https://aws.g
 $ ./scripts/copilot-init.sh <env> <domain>
 ```
 
+### Admin service
+
+Manual deploy `admin` endpoint service.
+
+```sh
+./scripts/copilot-admin-deploy.sh <env>
+```
+
 ### Switch maintenance
 
 1. Add listener rule to show maintenance to ALB that created by AWS Copilot.

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,7 @@
 class PagesController < ApplicationController
   def main
   end
+
+  def admin
+  end
 end

--- a/app/views/pages/admin.html.erb
+++ b/app/views/pages/admin.html.erb
@@ -1,0 +1,14 @@
+<h1>Admin Page</h1>
+
+<dl>
+  <dt>Scheme</dt>
+  <dd><%= request.scheme %></dt>
+  <dt>- Host</dt>
+  <dd><%= request.host %></dd>
+  <dt>- IP Address</dt>
+  <dd><%= request.remote_ip %><dt>
+  <dt>- User Agent</dt>
+  <dd><%= request.user_agent %>
+</dl>
+
+- <%= link_to "People Page", people_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   root 'pages#main'
 
   resources :people
+  get '/admin', to: 'pages#admin'
 end

--- a/copilot/admin-rails/manifest.yml
+++ b/copilot/admin-rails/manifest.yml
@@ -1,0 +1,85 @@
+# The manifest for the "rails" service.
+# Read the full specification for the "Load Balanced Web Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/
+
+# Your service name will be used in naming your resources like log groups, ECS services, etc.
+name: rails
+type: Load Balanced Web Service
+
+# Distribute traffic to your service.
+http:
+  # Requests to this path will be forwarded to your service.
+  # To match all requests you can use the "/" path.
+  path: '/'
+  # You can specify a custom health check path. The default is "/".
+  healthcheck:
+    path: '/healthcheck'
+    healthy_threshold: 2
+    unhealthy_threshold: 2
+    interval: 5s
+    timeout: 2s
+
+  # ロードバランサーのターゲットコンテナは Service のコンテナの代わりにサイドカーの`nginx`を指定
+  targetContainer: 'nginx'
+
+# Configuration for your containers and service.
+image:
+  location: 353381651656.dkr.ecr.ap-northeast-1.amazonaws.com/chronos/rails:<image_tag>
+  # Port exposed through your container to route traffic to it.
+  port: 3000
+
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
+count: 1       # Number of tasks that should be running in your service.
+
+exec: true     # Enable running commands in your container.
+
+sidecars:
+  nginx:
+    image: 353381651656.dkr.ecr.ap-northeast-1.amazonaws.com/chronos/nginx:latest
+    port: 80
+    variables:
+      RAILS_HOST: http://localhost:3000
+  # https://docs.datadoghq.com/integrations/ecs_fargate/?tab=fluentbitandfirelens#trace-collection
+  datadog-agent:
+    image: datadog/agent:latest
+    port: 8126
+    secrets:
+      DD_API_KEY: /copilot/chronos/dev/secrets/DATADOG_API_KEY
+    variables:
+      ECS_FARGATE: true
+      DD_APM_ENABLED: true
+      DD_SERVICE: chronos-rails
+      DD_DOCKER_ENV_AS_TAGS: true
+
+logging:
+  destination:
+    # https://docs.aws.amazon.com/AmazonECS/latest/userguide/firelens-example-taskdefs.html#firelens-example-firehose
+    Name: firehose
+    region: ap-northeast-1
+    delivery_stream: chronos-rails-datadog
+
+# Optional fields for more advanced use-cases.
+#
+variables:                    # Pass environment variables as key value pairs.
+  RAILS_LOG_TO_STDOUT: true
+
+secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+# GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
+
+# You can override any of the values defined above by environment.
+environments:
+  dev:
+    sidecars:
+      datadog-agent:
+        variables:
+          DD_ENV: dev
+    secrets:
+      RAILS_MASTER_KEY: /copilot/chronos/dev/secrets/RAILS_MASTER_KEY
+  staging:
+    sidecars:
+      datadog-agent:
+        variables:
+          DD_ENV: staging
+    secrets:
+      RAILS_MASTER_KEY: /copilot/chronos/staging/secrets/RAILS_MASTER_KEY

--- a/copilot/admin-rails/manifest.yml
+++ b/copilot/admin-rails/manifest.yml
@@ -3,14 +3,14 @@
 #  https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/
 
 # Your service name will be used in naming your resources like log groups, ECS services, etc.
-name: rails
+name: admin-rails
 type: Load Balanced Web Service
 
 # Distribute traffic to your service.
 http:
   # Requests to this path will be forwarded to your service.
   # To match all requests you can use the "/" path.
-  path: '/'
+  path: 'admin'
   # You can specify a custom health check path. The default is "/".
   healthcheck:
     path: '/healthcheck'
@@ -49,7 +49,7 @@ sidecars:
     variables:
       ECS_FARGATE: true
       DD_APM_ENABLED: true
-      DD_SERVICE: chronos-rails
+      DD_SERVICE: chronos-admin-rails
       DD_DOCKER_ENV_AS_TAGS: true
 
 logging:

--- a/copilot/admin-rails/manifest.yml
+++ b/copilot/admin-rails/manifest.yml
@@ -67,7 +67,7 @@ variables:                    # Pass environment variables as key value pairs.
 secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   # Get RDS connection configuration from copilot command bellow
   # `copilot svc show -n rails --json | jq '.secrets[] | select(.name == "RAILSCLUSTER_SECRET").valueFrom'`
-  RAILSCLUSTER_SECRET:
+  RAILSCLUSTER_SECRET: <RAILSCLUSTER_SECRET>
 
 # You can override any of the values defined above by environment.
 environments:

--- a/copilot/admin-rails/manifest.yml
+++ b/copilot/admin-rails/manifest.yml
@@ -65,7 +65,9 @@ variables:                    # Pass environment variables as key value pairs.
   RAILS_LOG_TO_STDOUT: true
 
 secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
-# GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
+  # Get RDS connection configuration from copilot command bellow
+  # `copilot svc show -n rails --json | jq '.secrets[] | select(.name == "RAILSCLUSTER_SECRET").valueFrom'`
+  RAILSCLUSTER_SECRET:
 
 # You can override any of the values defined above by environment.
 environments:

--- a/scripts/copilot-admin-deploy.sh
+++ b/scripts/copilot-admin-deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+env=$1
+
+echo "(1/3) Fetch RAILSCLUSTER_SECRET"
+RAILSCLUSTER_SECRET=$(copilot svc show -n rails --json | jq -r '.secrets[] | select(.name == "RAILSCLUSTER_SECRET").valueFrom')
+echo $RAILSCLUSTER_SECRET
+
+manifest_path='./copilot/admin-rails/manifest.yml'
+echo "(2/3) Set RAILSCLUSTER_SECRE to $manifest_path"
+sed -i -e "s/<RAILSCLUSTER_SECRET>/$RAILSCLUSTER_SECRET/" $manifest_path
+
+echo "(3/3) Deploy admin-rails service"
+copilot svc deploy --name admin-rails --env $env

--- a/scripts/copilot-init.sh
+++ b/scripts/copilot-init.sh
@@ -23,9 +23,15 @@ else
   echo "Skip to set secrets"
 fi
 
-echo "(4/5) Create service"
+echo "(4/5) Create services"
 copilot svc init \
   --name rails \
+  --svc-type "Load Balanced Web Service" \
+  --dockerfile Dockerfile.prod \
+  --port 3000
+
+copilot svc init \
+  --name admin-rails \
   --svc-type "Load Balanced Web Service" \
   --dockerfile Dockerfile.prod \
   --port 3000


### PR DESCRIPTION
## Description

Added `/admin` path routing to ALB listener rule.

![スクリーンショット 2021-06-09 15 22 46](https://user-images.githubusercontent.com/5207601/121303917-9dee7700-c936-11eb-9ef3-ed1eae46d446.png)

## TODO
- [x] Add `/admin` endpoint to Rails
- [x] Add new Load Balanced Web Service to response `/admin` request
- [x] Add `admin-rails` deploy scripts