### PR TITLE
Improve Datadog integratoin 🐶 

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -4,6 +4,7 @@ WORKDIR /app
 
 # bundler configuration
 ENV LANG=C.UTF-8
+ENV TZ=Asia/Tokyo
 ENV RAILS_ENV production
 ENV BUNDLE_DEPLOYMENT true
 ENV BUNDLE_PATH vendor/bundle

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  # config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,4 +117,12 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  # Datadog
+  # Ignore health check logs
+  # https://github.com/linqueta/rails-healthcheck#ignoring-logs
+  filter = Datadog::Pipeline::SpanFilter.new do |span|
+    span.name == 'rack.request' && span.get_tag('http.url') == Healthcheck.configuration.route
+  end
+  Datadog::Pipeline.before_flush(filter)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,4 +125,25 @@ Rails.application.configure do
     span.name == 'rack.request' && span.get_tag('http.url') == Healthcheck.configuration.route
   end
   Datadog::Pipeline.before_flush(filter)
+
+  # Lograge
+  # 現在のスレッドのトレース情報を取得
+  # https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/ruby/#ruby-%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AB%E3%83%AD%E3%82%AE%E3%83%B3%E3%82%B0%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
+  config.lograge.custom_options = lambda do |event|
+    correlation = Datadog.tracer.active_correlation
+
+    {
+      ip: event.payload[:ip],
+      # https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/ruby/
+      dd: {
+        trace_id: correlation.trace_id.to_s,
+        span_id: correlation.span_id.to_s,
+        env: correlation.env.to_s,
+        service: correlation.service.to_s,
+        version: correlation.version.to_s
+      },
+      ddsource: ["ruby"],
+      params: event.payload[:params]
+    }
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,6 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -124,25 +124,4 @@ Rails.application.configure do
     span.name == 'rack.request' && span.get_tag('http.url') == Healthcheck.configuration.route
   end
   Datadog::Pipeline.before_flush(filter)
-
-  # Lograge
-  # 現在のスレッドのトレース情報を取得
-  # https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/ruby/#ruby-%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AB%E3%83%AD%E3%82%AE%E3%83%B3%E3%82%B0%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
-  config.lograge.custom_options = lambda do |event|
-    correlation = Datadog.tracer.active_correlation
-
-    {
-      ip: event.payload[:ip],
-      # https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/ruby/
-      dd: {
-        trace_id: correlation.trace_id.to_s,
-        span_id: correlation.span_id.to_s,
-        env: correlation.env.to_s,
-        service: correlation.service.to_s,
-        version: correlation.version.to_s
-      },
-      ddsource: ["ruby"],
-      params: event.payload[:params]
-    }
-  end
 end

--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -1,11 +1,3 @@
 Datadog.configure do |c|
   c.use :rails, service_name: 'chronos-rails'
 end
-
-# Ignore health check logs
-# https://github.com/linqueta/rails-healthcheck#ignoring-logs
-filter = Datadog::Pipeline::SpanFilter.new do |span|
-  span.name == 'rack.request' && span.get_tag('http.url') == Healthcheck.configuration.route
-end
-
-Datadog::Pipeline.before_flush(filter)

--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -1,3 +1,11 @@
 Datadog.configure do |c|
   c.use :rails, service_name: 'chronos-rails'
 end
+
+# Ignore health check logs
+# https://github.com/linqueta/rails-healthcheck#ignoring-logs
+filter = Datadog::Pipeline::SpanFilter.new do |span|
+  span.name == 'rack.request' && span.get_tag('http.url') == Healthcheck.configuration.route
+end
+
+Datadog::Pipeline.before_flush(filter)

--- a/config/initializers/datadog-tracer.rb
+++ b/config/initializers/datadog-tracer.rb
@@ -1,3 +1,3 @@
 Datadog.configure do |c|
-  c.use :rails, service_name: 'chronos-rails'
+  c.use :rails
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -8,4 +8,30 @@ Rails.application.configure do
   # Exclude heathcheck logs from rails logs
   # https://github.com/linqueta/rails-healthcheck#ignoring-logs
   config.lograge.ignore_actions = [Healthcheck::CONTROLLER_ACTION]
+
+  config.lograge.custom_payload do |controller|
+    {
+      request_id: controller.request.request_id
+    }
+  end
+
+
+  # 現在のスレッドのトレース情報を取得
+  # https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/ruby/#ruby-%E3%82%A2%E3%83%97%E3%83%AA%E3%82%B1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AB%E3%83%AD%E3%82%AE%E3%83%B3%E3%82%B0%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88
+  config.lograge.custom_options = lambda do |event|
+    correlation = Datadog.tracer.active_correlation
+    {
+      ip: event.payload[:ip],
+      # https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/ruby/
+      dd: {
+        trace_id: correlation.trace_id.to_s,
+        span_id: correlation.span_id.to_s,
+        env: correlation.env.to_s,
+        service: correlation.service.to_s,
+        version: correlation.version.to_s
+      },
+      ddsource: ["ruby"],
+      params: event.payload[:params]
+    }
+  end
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -3,24 +3,6 @@ Rails.application.configure do
   config.lograge.formatter = Lograge::Formatters::Json.new
   config.lograge.ignore_actions = [Healthcheck::CONTROLLER_ACTION]
 
-  # 現在のスレッドのトレース情報を取得
-  correlation = Datadog.tracer.active_correlation
-  config.lograge.custom_options = lambda do |event|
-    {
-      ip: event.payload[:ip],
-      # https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/ruby/
-      dd: {
-        trace_id: correlation.trace_id.to_s,
-        span_id: correlation.span_id.to_s,
-        env: correlation.env.to_s,
-        service: correlation.service.to_s,
-        version: correlation.version.to_s
-      },
-      ddsource: ["ruby"],
-      params: event.payload[:params]
-    }
-  end
-
   # Exclude heathcheck logs from rails logs
   # https://github.com/linqueta/rails-healthcheck#ignoring-logs
   config.lograge.ignore_actions = [Healthcheck::CONTROLLER_ACTION]

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -2,6 +2,9 @@ Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Json.new
 
+  ## Disables log coloration
+  config.colorize_logging = false
+
   # Exclude heathcheck logs from rails logs
   # https://github.com/linqueta/rails-healthcheck#ignoring-logs
   config.lograge.ignore_actions = [Healthcheck::CONTROLLER_ACTION]

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,7 +1,6 @@
 Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Json.new
-  config.lograge.ignore_actions = [Healthcheck::CONTROLLER_ACTION]
 
   # Exclude heathcheck logs from rails logs
   # https://github.com/linqueta/rails-healthcheck#ignoring-logs

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,6 +1,7 @@
 Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Json.new
+  config.lograge.ignore_actions = [Healthcheck::CONTROLLER_ACTION]
 
   # 現在のスレッドのトレース情報を取得
   correlation = Datadog.tracer.active_correlation

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -2,9 +2,20 @@ Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Json.new
 
+  # 現在のスレッドのトレース情報を取得
+  correlation = Datadog.tracer.active_correlation
   config.lograge.custom_options = lambda do |event|
     {
       ip: event.payload[:ip],
+      # https://docs.datadoghq.com/ja/tracing/connect_logs_and_traces/ruby/
+      dd: {
+        trace_id: correlation.trace_id.to_s,
+        span_id: correlation.span_id.to_s,
+        env: correlation.env.to_s,
+        service: correlation.service.to_s,
+        version: correlation.version.to_s
+      },
+      ddsource: ["ruby"],
       params: event.payload[:params]
     }
   end

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -65,7 +65,6 @@ logging:
   enableMetadata: true
   secretOptions:
     apikey: /copilot/chronos/dev/secrets/DATADOG_API_KEY
-  configFilePath: /fluent-bit/configs/parse-json.conf
 
 # Optional fields for more advanced use-cases.
 #

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -56,10 +56,15 @@ sidecars:
 
 logging:
   destination:
-    # https://docs.aws.amazon.com/AmazonECS/latest/userguide/firelens-example-taskdefs.html#firelens-example-firehose
-    Name: firehose
-    region: ap-northeast-1
-    delivery_stream: chronos-rails-datadog
+    Name: datadog
+    Host: http-intake.logs.datadoghq.com
+    TLS: 'on'
+    dd_service: chronos-rails
+    dd_source: ruby
+    provider: ecs
+  enableMetadata: true
+  secretOptions:
+    apikey: /copilot/chronos/dev/secrets/DATADOG_API_KEY
 
 # Optional fields for more advanced use-cases.
 #

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -70,6 +70,7 @@ logging:
 #
 variables:                    # Pass environment variables as key value pairs.
   RAILS_LOG_TO_STDOUT: true
+  RAILS_SERVE_STATIC_FILES: true
   DD_SERVICE: chronos-rails
   DD_VERSION: 1.0.0
 

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -65,6 +65,7 @@ logging:
   enableMetadata: true
   secretOptions:
     apikey: /copilot/chronos/dev/secrets/DATADOG_API_KEY
+  configFilePath: /fluent-bit/configs/parse-json.conf
 
 # Optional fields for more advanced use-cases.
 #

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -65,6 +65,8 @@ logging:
 #
 variables:                    # Pass environment variables as key value pairs.
   RAILS_LOG_TO_STDOUT: true
+  DD_SERVICE: chronos-rails
+  DD_VERSION: 1.0.0
 
 secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 # GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
@@ -72,6 +74,8 @@ secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 # You can override any of the values defined above by environment.
 environments:
   dev:
+    variables:
+      DD_ENV: dev
     sidecars:
       datadog-agent:
         variables:
@@ -79,6 +83,8 @@ environments:
     secrets:
       RAILS_MASTER_KEY: /copilot/chronos/dev/secrets/RAILS_MASTER_KEY
   staging:
+    variabels:
+      DD_ENV: staging
     sidecars:
       datadog-agent:
         variables:

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -48,9 +48,11 @@ sidecars:
       DD_API_KEY: /copilot/chronos/dev/secrets/DATADOG_API_KEY
     variables:
       ECS_FARGATE: true
+      DD_LOGS_ENABLED: true
+      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: true
       DD_APM_ENABLED: true
-      DD_SERVICE: chronos-rails
       DD_DOCKER_ENV_AS_TAGS: true
+      DD_SERVICE: chronos-rails
 
 logging:
   destination:

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -65,6 +65,8 @@ logging:
   enableMetadata: true
   secretOptions:
     apikey: /copilot/chronos/dev/secrets/DATADOG_API_KEY
+  # To parse Rails logs formatted as JSON by Lograge
+  # https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/parse-json
   configFilePath: /fluent-bit/configs/parse-json.conf
 
 # Optional fields for more advanced use-cases.


### PR DESCRIPTION
## Description

Connect Logs and APM trace with `trace_id`.
![スクリーンショット 2021-06-13 11 37 51](https://user-images.githubusercontent.com/5207601/121793694-aeeffe80-cc3c-11eb-881d-dc153b412bcb.png)
![スクリーンショット 2021-06-13 11 37 58](https://user-images.githubusercontent.com/5207601/121793696-b1525880-cc3c-11eb-8bf1-36948651bf20.png)



## TODO
- [x] Add `trace_id` and `span_id` to Rails logs
- [x] Send Rails logs to Datadog using Firelens instead of Kinesis Data Firehose
- [x] Add `DD_ENV`, `DD_SERVICE`, `DD_VERSION` tags through environment variables
- [x] Ignore health check logs in Datadog