### PR TITLE
Install session manager plugin before migration task to prevent aws cli warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,7 +110,12 @@ jobs:
       run: |
         copilot svc deploy --app chronos --env dev --name rails
 
-  
+    - name: Install session manager plugin
+      run: |
+        # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html#install-plugin-debian
+        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+        sudo dpkg -i session-manager-plugin.deb
+
     # TODO: Run migratoin before copilot sevice deployment
     - name: Excecute database migration
       run: |

--- a/scripts/copilot-init.sh
+++ b/scripts/copilot-init.sh
@@ -4,6 +4,7 @@ set -e -u
 
 env=$1
 domain=$2
+branch="${3:-main}"
 
 app_name=chronos
 
@@ -59,4 +60,4 @@ copilot job init \
   --schedule "cron(0 * * * ? *)"
 
 echo "(6/6) Execute deploy job in GitHub Actons"
-gh workflow run --ref main
+gh workflow run --ref $branch


### PR DESCRIPTION
## Description
Ubuntu latest of GitHub Actions runtime is installed AWS CLI Session manager plugin 1.2.54.0.
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#cli-tools

Run `copilot svc exec` command, AWS CLI check Session manager plugin version. If it too old, update confirmation message is shown. 
```
Run # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
  # https://aws.github.io/copilot-cli/docs/commands/svc-exec/
  copilot svc exec \
    --command 'bin/rails db:migrate' \
    --app chronos \
    --name rails \
    --env dev
  shell: /usr/bin/bash -e {0}
  env:
    AWS_DEFAULT_REGION: ap-northeast-1
    AWS_REGION: ap-northeast-1
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***

  Looks like the Session Manager plugin is using version 1.2.54.0.
Would you like to update it to the latest version 1.2.205.0? (y/N) 25l25h✘ prompt to confirm updating the plugin: EOF
Error: Process completed with exit code 1.
```
ref: https://github.com/shgtkshruch/chronos/runs/2807049368?check_suite_focus=true

This PR to install latest session manager plugin in GitHub Actions to prevent AWS CLI warning.

## TODO
- [x] Add a step to install Session manager plugin before `copilot svc exec` in GitHub Actions
