### PR TITLE
Change `ddsource` format from array to string to enable log parse in Datadog 🐶 

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
         service: correlation.service.to_s,
         version: correlation.version.to_s
       },
-      ddsource: ["ruby"],
+      ddsource: "ruby",
       params: event.payload[:params]
     }
   end


### PR DESCRIPTION
## Description

### Before
![スクリーンショット 2021-06-20 12 01 39](https://user-images.githubusercontent.com/5207601/122660813-65b12900-d1bf-11eb-909a-f7f12fe4f3fb.png)

### After

![スクリーンショット 2021-06-20 12 01 50](https://user-images.githubusercontent.com/5207601/122660817-6944b000-d1bf-11eb-8038-7f6c8183202d.png)

## TODO
- [x] Change `ddsource` type from array to string