### PR TITLE
Fix Nginx ECR image tag to `latest`

### DIFF
--- a/scripts/ecr-nginx.sh
+++ b/scripts/ecr-nginx.sh
@@ -6,8 +6,7 @@ aws_account_id=353381651656
 ecr_endpoint=$aws_account_id.dkr.ecr.ap-northeast-1.amazonaws.com
 app_name=chronos
 repo_name=$app_name/nginx
-version=$(git rev-parse HEAD)
-tag_name=$ecr_endpoint/$repo_name:$version
+tag_name=$ecr_endpoint/$repo_name:latest
 
 echo "(1/4) Login ECR"
 aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin $ecr_endpoint


### PR DESCRIPTION
## Description

To easy deploy, set Nginx ECR image tag to `latest`.

## TODO
- [x] Fix Nginx ECR image tag to `latest`