### PR TITLE
Set custom domain to each copilot service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
         default: 'false'
 
 env:
-  COPILOT_VERSION: v1.8.0
+  COPILOT_VERSION: v1.8.2
 
 jobs:
   build-rails-image:

--- a/copilot/admin-rails/manifest.yml
+++ b/copilot/admin-rails/manifest.yml
@@ -93,6 +93,8 @@ secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 # You can override any of the values defined above by environment.
 environments:
   dev:
+    http:
+      alias: dev-admin-rails.shgtkshruch.com
     sidecars:
       datadog-agent:
         variables:
@@ -100,6 +102,8 @@ environments:
     secrets:
       RAILS_MASTER_KEY: /copilot/chronos/dev/secrets/RAILS_MASTER_KEY
   staging:
+    http:
+      alias: staging-admin-rails.shgtkshruch.com
     sidecars:
       datadog-agent:
         variables:

--- a/copilot/frontend/manifest.yml
+++ b/copilot/frontend/manifest.yml
@@ -4,7 +4,6 @@ type: Load Balanced Web Service
 http:
   path: '/'
   healthcheck: '/'
-  alias: 'frontend.shgtkshruch.com'
 
 image:
   build: frontend/Dockerfile
@@ -14,3 +13,11 @@ cpu: 256
 memory: 512
 count: 1
 exec: true
+
+environments:
+  dev:
+    http:
+      alias: dev-frontend.shgtkshruch.com
+  staging:
+    http:
+      alias: staging-frontend.shgtkshruch.com

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -94,6 +94,8 @@ secrets:       # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 # You can override any of the values defined above by environment.
 environments:
   dev:
+    http:
+      alias: dev-rails.shgtkshruch.com
     variables:
       DD_ENV: dev
     sidecars:
@@ -103,6 +105,8 @@ environments:
     secrets:
       RAILS_MASTER_KEY: /copilot/chronos/dev/secrets/RAILS_MASTER_KEY
   staging:
+    http:
+      alias: dev-rails.shgtkshruch.com
     variabels:
       DD_ENV: staging
     sidecars:

--- a/copilot/rails/manifest.yml
+++ b/copilot/rails/manifest.yml
@@ -106,7 +106,7 @@ environments:
       RAILS_MASTER_KEY: /copilot/chronos/dev/secrets/RAILS_MASTER_KEY
   staging:
     http:
-      alias: dev-rails.shgtkshruch.com
+      alias: staging-rails.shgtkshruch.com
     variabels:
       DD_ENV: staging
     sidecars:

--- a/scripts/copilot-init.sh
+++ b/scripts/copilot-init.sh
@@ -72,4 +72,4 @@ copilot job init \
   --schedule "cron(30 * * * ? *)"
 
 echo "(6/6) Execute deploy job in GitHub Actons"
-gh workflow run --ref $branch
+gh workflow run deploy.yml --ref $branch


### PR DESCRIPTION
## Description

Set custom domain to each copilot service.
Copilot 1.8.2, enable to set custom domain and enable to deploy same time multiple copilot services.
https://github.com/aws/copilot-cli/releases/tag/v1.8.2

![スクリーンショット 2021-06-30 12 56 59](https://user-images.githubusercontent.com/5207601/123899727-b1738780-d9a2-11eb-8e62-a542c2f246d9.png)
ref: https://github.com/shgtkshruch/chronos/actions/runs/984973204

## TODO
- [x] Upgrade copilot version to 1.8.2 to set custom domain
- [x] Set custom domain to each copilot service