### PR TITLE
Pass `RAILS_MASTER_KEY` through docker secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,8 @@ jobs:
         file: ./Dockerfile.prod
         push: true
         tags: ${{ steps.login-ecr.outputs.registry }}/chronos/rails:${{ github.sha }}
+        secrets: |
+            "master_key=${{ secrets.RAILS_MASTER_KEY }}"
         cache-from: |
           type=local,src=/tmp/.buildx-cache-new/bundle
           type=local,src=/tmp/.buildx-cache-new/npm

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -48,9 +48,9 @@ COPY . .
 COPY --from=bundle /app/vendor/bundle /app/vendor/bundle
 COPY --from=npm /app/node_modules node_modules
 
-# Set a dummy value to avoid errors when building docker image.
-# refs: https://github.com/rails/rails/issues/32947
-RUN SECRET_KEY_BASE=dummy bin/rails assets:precompile \
+# refs: https://github.com/rails/rails/issues/32947#issuecomment-653478965
+RUN --mount=type=secret,id=master_key,dst=/app/config/master.key \
+      bin/rails assets:precompile \
       && rm -rf tmp/cache/*
 
 FROM base AS main

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 $ COMPOSE_DOCKER_CLI_BUILD=1 docker-compose build
 ```
 
+Build docker image for production.
+
+```sh
+$ docker build -f Dockerfile.prod --secret id=master_key,src=config/master.key .
+```
+
 ## Dev
 
 ```sh


### PR DESCRIPTION
## Description

In production, docker build need `RAILS_MASTER_KEY` to asset:precompile, so pass `RAILS_MASTER_KEY` through docker secret.
https://docs.docker.com/engine/swarm/secrets/

In GitHub Actions, I use `docker/build-push-action` and it has secret option.
https://github.com/docker/build-push-action/blob/master/docs/advanced/secrets.md

## Reference
- https://github.com/rails/rails/issues/32947#issuecomment-653478965

## TODO
- [x] Enable build docker image for production in local
- [x] Enable build docker image for production in GitHub Actions with docker/build-push-action
- [x] Update README