### PR TITLE
Enable Docker layer cache in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
         file: ./Dockerfile.prod
         target: bundle
         cache-from: type=local,src=/tmp/.buildx-cache/bundle
-        cache-to: type=local,dest=/tmp/.buildx-cache-new/bundle
+        cache-to: type=local,dest=/tmp/.buildx-cache-new/bundle,mode=max
 
     - name: Build npm stage
       uses: docker/build-push-action@v2
@@ -66,7 +66,7 @@ jobs:
         file: ./Dockerfile.prod
         target: npm
         cache-from: type=local,src=/tmp/.buildx-cache/npm
-        cache-to: type=local,dest=/tmp/.buildx-cache-new/npm
+        cache-to: type=local,dest=/tmp/.buildx-cache-new/npm,mode=max
 
     - name: Build docker image
       id: docker-build


### PR DESCRIPTION
## Description

Enable Docker layer cache in GitHub Actions.
- https://github.com/docker/build-push-action/pull/406
- https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#local-cache

### Before
![スクリーンショット 2021-07-31 21 22 26](https://user-images.githubusercontent.com/5207601/127739766-7e9abf9a-57f4-468c-a406-37ef0a3d799f.png)

https://github.com/shgtkshruch/chronos/runs/3208920500?check_suite_focus=true

### After
![スクリーンショット 2021-07-31 21 23 04](https://user-images.githubusercontent.com/5207601/127739769-4fcdaf12-e10a-4c1c-81be-c0b80d3f7949.png)

https://github.com/shgtkshruch/chronos/runs/3208936281?check_suite_focus=true

## TODO
- [x] Add `mode=max` to `cache-to` option in [`docker/build-push-action@v2`](https://github.com/docker/build-push-action)